### PR TITLE
fix: invalid link to preview website

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then check your edits on http://localhost:1313/.
 
 ## Online Preview
 
-Any merged updates are pushed to [owasp-modsecurity.github.io](owasp-modsecurity.github.io/website/) for preview.
+Any merged updates are pushed to [owasp-modsecurity.github.io](https://owasp-modsecurity.github.io/website/) for preview.
 
 ## Authors
 


### PR DESCRIPTION
The website preview link is being sent to https://github.com/owasp-modsecurity/website/blob/main/owasp-modsecurity.github.io/website instead of https://owasp-modsecurity.github.io/website/ because of the missing protocol in the URL.