### PR TITLE
(docs): Replace CRS/CoreRuleSet by ModSecurity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CRS Project Website Repository
+# OWASP ModSecurity Project Website Repository
 
 This repository contains the website for the OWASP Modsecurity Project.
 

--- a/config/production/hugo.yaml
+++ b/config/production/hugo.yaml
@@ -1,6 +1,6 @@
 ######################## production configuration ####################
 # The base URL of your site (required). This will be prepended to all relative URLs.
-baseURL: "https://modsecurity.org/"
+baseURL: "https://www.modsecurity.org/"
 googleAnalytics: 
 enableRobotsTXT: true
 build:

--- a/content/pages/privacy-policy.md
+++ b/content/pages/privacy-policy.md
@@ -53,7 +53,7 @@ The right to access - You have the right to request copies of your personal data
 
 The right to erasure - You have the right to request that we erase your personal data, under certain conditions.
 
-If you make a request, we have one month to respond to you. If you would like to exercise any of these rights, please contact us at <info@coreruleset.org>.
+If you make a request, we have one month to respond to you. If you would like to exercise any of these rights, please contact us at <modsecurity@owasp.org>.
 
 ### How do we use cookies?
 


### PR DESCRIPTION
Replaced CRS/CoreRuleSet occurrences by ModSecurity (where it was needed).