### PR TITLE
docs: Add blog post about PCRE2

### DIFF
--- a/content/blog/2025-02-08-use-pcre2.md
+++ b/content/blog/2025-02-08-use-pcre2.md
@@ -1,0 +1,19 @@
+---
+title: 'Use PCRE2 as default - 2025 February'
+date: '2025-02-18T00:00:00+02:00'
+author: airween
+---
+
+It's time to switch to using the PCRE library.
+
+<!--more-->
+
+Libmodsecurity3 and mod_security2 have a very important component, namely PCRE. Both engines use PCRE3 by default, but they also support PCRE2. If you want to use it, all you have to do is specify the necessary switch when compiling: `--with-pcre2`.
+
+We are sure it's time to change this behavior. With [this](https://github.com/owasp-modsecurity/ModSecurity/pull/3321) pull request the default PCRE engine in libmodsecurity3 will be PCRE2. Don't worry if you have an old system, it's sill possible to use the old regex engine with switch `--with-pcre`.
+
+We are working on a similar PR for mod_security2.
+
+Summary: in the next releases (both mod_security2 and libmodsecurity3) the default PCRE engine will change and both will use PCRE2.
+
+If you have any perception please leave a comment under the mentioned PR above.


### PR DESCRIPTION
New blog post about making PCRE2 as default regex engine.